### PR TITLE
Add Meta tag for the Atom feed

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,7 @@
         <link rel="apple-touch-icon-precomposed" sizes="114x114" href="ico/apple-touch-icon-114-precomposed.png">
         <link rel="apple-touch-icon-precomposed" sizes="72x72" href="ico/apple-touch-icon-72-precomposed.png">
         <link rel="apple-touch-icon-precomposed" href="ico/apple-touch-icon-57-precomposed.png">
+        <link rel="alternate" type="application/atom+xml" title="Atom Feed for NPR News Apps blog" href="http://blog.apps.npr.org/atom.xml">
     </head>
     <body>
     <div id="fb-root"></div>


### PR DESCRIPTION
Just a simple addition of to the layout.

``` html
<link rel="alternate" type="application/atom+xml" title="Atom Feed for NPR News Apps blog" href="http://blog.apps.npr.org/atom.xml">
```

Closes issue #22 - Add meta tag
