### PR TITLE
fix 'it should look like this:' section

### DIFF
--- a/_posts/2013-06-06-how-to-setup-a-developers-environment.markdown
+++ b/_posts/2013-06-06-how-to-setup-a-developers-environment.markdown
@@ -118,7 +118,7 @@ It should look like this:
 
 	export PATH=/usr/local/bin:$PATH
 	export PATH=/usr/local/lib/python2.7/site-packages:$PATH
-	source /usr/local/share/python/virtualenvwrapper_lazy.sh
+	source /usr/local/bin/virtualenvwrapper_lazy.sh
 
 To exit `less`, press "Q".
 


### PR DESCRIPTION
The section that describes how your `.bash_profile` should look is not consistent with the instructions that came before and also isn't correct.
