### PR TITLE
Updating pygments configuration to conform to the new syntax

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,2 @@
-pygments: true
+highlighter: pygments
 markdown: redcarpet


### PR DESCRIPTION
Addressing Jekyll warning described in issue #46