### PR TITLE
Add S3 bucket configuration instructions to the prerequisite section

### DIFF
--- a/_posts/2014-09-08-how-to-setup-the-npr-app-template-for-you-and-your-news-org.markdown
+++ b/_posts/2014-09-08-how-to-setup-the-npr-app-template-for-you-and-your-news-org.markdown
@@ -27,7 +27,7 @@ In this post, you will learn how to:
 
 Our app template relies on a UNIX-based development environment and working knowledge of the command line. We have a Python and Node-based stack. Thus, if you are new to all of this, you should probably read our [development environment blog post](http://blog.apps.npr.org/2013/06/06/how-to-setup-a-developers-environment.html) first and make sure your environment matches ours. Namely, you should have Python 2.7 and the latest version of Node installed.
 
-Also, all of our projects are deployed from the template to Amazon S3. You should have three buckets configured: one for production, one for staging and one for synchronizing large media assets (like images) across computers. For example, we use apps.npr.org, stage-apps.npr.org and assets.apps.npr.org for our three buckets, respectively.
+Also, all of our projects are deployed from the template to Amazon S3. You should have three buckets configured: one for production, one for staging and one for synchronizing large media assets (like images) across computers. For example, we use apps.npr.org, stage-apps.npr.org and assets.apps.npr.org for our three buckets, respectively. Each bucket will need to have [enabled website hosting](https://docs.aws.amazon.com/AmazonS3/latest/dev/EnableWebsiteHosting.html) and have a [bucket policy allowing website access].
 
 ## Cloning the template
 


### PR DESCRIPTION
This provides additional information, without which it is difficult to get an S3-hosted app template up and running successfully.

I'm making the PR to this documentation because this blog post is referenced in https://github.com/nprapps/app-template#about-this-template as being the resource for people outside NPR seeking to use the app template for themselves.

In discussion in #helpme in the newsnerdery.org slack on Friday, September 1, 2017, multiple other people mentioned they had run into the problem I ran into: a newly-created bucket was not publicly accessible as a website. Adding bucket configuration to the instructions would hopefully lessen the chance of that happening in the future.

However: accepting this PR means that you're linking to Amazon's documentation, the URLs for which may change without notice. Hopefully if Amazon changes these URLs they'll set up redirects, or someone will let you know that the links are broken, and the links will be able to be updated.

If the lawyers ask: yes, I grant NPR the necessary licenses to use this content. If there's paperwork that needs to be signed, let me know and we'll figure that out.